### PR TITLE
Glog 46 fix error 429 too many requests caused by exceeding ratelimit

### DIFF
--- a/pages/testSlider.js
+++ b/pages/testSlider.js
@@ -2,25 +2,25 @@ import React from "react";
 import FeaturedSlider from "../components/FeaturedSlider";
 import NavBar from "../components/NavBar";
 import Slider from "../components/Slider";
+import buildRequest from "../utils/buildRequest";
 import requests from "../utils/requests";
 
 function myCarousel({ gameMasterList }) {
   return (
     <>
       <NavBar />
-      <FeaturedSlider gameProp={gameMasterList[0].gameList} />
       {gameMasterList.map((obj) => {
-        return obj.id === 0 ? (
+        return obj.name === "Top Games" ? (
           <FeaturedSlider
             key={`slider-genre-${obj.id}`}
-            gameProp={obj.gameList}
-            sliderTitle={obj.title}
+            gameProp={obj.result}
+            sliderTitle={obj.name}
           />
         ) : (
           <Slider
             key={`slider-genre-${obj.id}`}
-            gameProp={obj.gameList}
-            sliderTitle={obj.title}
+            gameProp={obj.result}
+            sliderTitle={obj.name}
           />
         );
       })}
@@ -29,33 +29,48 @@ function myCarousel({ gameMasterList }) {
 }
 
 export async function getServerSideProps() {
-  // Array of Promises
-  let p = [];
-  // Array of Carousel data objects
-  let data = [];
+  // // Array of Promises
+  // let p = [];
+  // // Array of Carousel data objects
+  // let data = [];
 
-  // Loop through all object requests under home.
-  for (const listPromiseObj in requests.home) {
-    // Save each promise to the promise array
-    p.push(requests.home[listPromiseObj].promise);
-    // Add Carousel Title to Titles array
-    data.push({
-      id: requests.home[listPromiseObj].id,
-      title: requests.home[listPromiseObj].title,
-    });
+  // // Loop through all object requests under home.
+  // for (const listPromiseObj in requests.home) {
+  //   // Save each promise to the promise array
+  //   p.push(requests.home[listPromiseObj].promise);
+  //   // Add Carousel Title to Titles array
+  //   data.push({
+  //     id: requests.home[listPromiseObj].id,
+  //     title: requests.home[listPromiseObj].title,
+  //   });
+  // }
+
+  // // Resolve all Promises in Promise array in parallel
+  // const pResponse = await Promise.all(p);
+
+  // // Create new Array of Carousel data objects
+  // const carousels = pResponse.map((list, idx) => {
+  //   return { id: data[idx].id, title: data[idx].title, gameList: list };
+  // });
+
+  let multiQueryBody = "";
+  let i = 0;
+  for (const listPromiseObj in requests.home2) {
+    i++;
+    multiQueryBody = multiQueryBody.concat(
+      `query games "${requests.home2[listPromiseObj].title}" { ${requests.home2[listPromiseObj].query} };\n`
+    );
+
+    if (i == 10) {
+      break;
+    }
   }
 
-  // Resolve all Promises in Promise array in parallel
-  const pResponse = await Promise.all(p);
-
-  // Create new Array of Carousel data objects
-  const carousels = pResponse.map((list, idx) => {
-    return { id: data[idx].id, title: data[idx].title, gameList: list };
-  });
+  const response = await buildRequest("igdb", "multiquery", multiQueryBody);
 
   return {
     props: {
-      gameMasterList: carousels,
+      gameMasterList: response,
     },
   };
 }

--- a/pages/testSlider.js
+++ b/pages/testSlider.js
@@ -9,16 +9,16 @@ function myCarousel({ gameMasterList }) {
   return (
     <>
       <NavBar />
-      {gameMasterList.map((obj) => {
+      {gameMasterList.map((obj, idx) => {
         return obj.name === "Top Games" ? (
           <FeaturedSlider
-            key={`slider-genre-${obj.id}`}
+            key={`slider-genre-${obj.idx}`}
             gameProp={obj.result}
             sliderTitle={obj.name}
           />
         ) : (
           <Slider
-            key={`slider-genre-${obj.id}`}
+            key={`slider-genre-${obj.idx}`}
             gameProp={obj.result}
             sliderTitle={obj.name}
           />
@@ -29,44 +29,27 @@ function myCarousel({ gameMasterList }) {
 }
 
 export async function getServerSideProps() {
-  // // Array of Promises
-  // let p = [];
-  // // Array of Carousel data objects
-  // let data = [];
-
-  // // Loop through all object requests under home.
-  // for (const listPromiseObj in requests.home) {
-  //   // Save each promise to the promise array
-  //   p.push(requests.home[listPromiseObj].promise);
-  //   // Add Carousel Title to Titles array
-  //   data.push({
-  //     id: requests.home[listPromiseObj].id,
-  //     title: requests.home[listPromiseObj].title,
-  //   });
-  // }
-
-  // // Resolve all Promises in Promise array in parallel
-  // const pResponse = await Promise.all(p);
-
-  // // Create new Array of Carousel data objects
-  // const carousels = pResponse.map((list, idx) => {
-  //   return { id: data[idx].id, title: data[idx].title, gameList: list };
-  // });
-
-  let multiQueryBody = "";
+  //** NOTE: Multiquery endpoint only allows 10 queries per call */
+  let multiQueryBody1 = "";
+  let multiQueryBody2 = "";
   let i = 0;
-  for (const listPromiseObj in requests.home2) {
+  for (const listPromiseObj in requests.home) {
     i++;
-    multiQueryBody = multiQueryBody.concat(
-      `query games "${requests.home2[listPromiseObj].title}" { ${requests.home2[listPromiseObj].query} };\n`
-    );
-
-    if (i == 10) {
-      break;
-    }
+    if (i <= 10) {
+      multiQueryBody1 = multiQueryBody1.concat(
+        `query games "${requests.home[listPromiseObj].title}" { ${requests.home[listPromiseObj].query} };\n`
+      );
+    } else if (i > 10 && i <= 20) {
+      multiQueryBody2 = multiQueryBody2.concat(
+        `query games "${requests.home[listPromiseObj].title}" { ${requests.home[listPromiseObj].query} };\n`
+      );
+    } else break;
   }
 
-  const response = await buildRequest("igdb", "multiquery", multiQueryBody);
+  const response1 = await buildRequest("igdb", "multiquery", multiQueryBody1);
+  const response2 = await buildRequest("igdb", "multiquery", multiQueryBody2);
+
+  const response = [...response1, ...response2];
 
   return {
     props: {

--- a/utils/requests.js
+++ b/utils/requests.js
@@ -219,4 +219,160 @@ export default {
     //   ),
     // },
   },
+
+  home2: {
+    TopGames: {
+      id: 0,
+      title: "Top Games",
+      query:
+        "fields name, slug, cover.url, screenshots.url, rating, summary; sort aggregated_rating_count desc; where aggregated_rating >= 90; limit 20;",
+    },
+    PointandClick: {
+      id: 2,
+      title: "Point-and-Click",
+      query:
+        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (2); limit 20;",
+    },
+    Fighting: {
+      id: 4,
+      title: "Fighting",
+      query:
+        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (4); limit 20;",
+    },
+    Shooter: {
+      id: 5,
+      title: "Shooter",
+      query:
+        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (5); limit 20;",
+    },
+    Music: {
+      id: 7,
+      title: "Music",
+      query:
+        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (7); limit 20;",
+    },
+    Platform: {
+      id: 8,
+      title: "Platform",
+      query:
+        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (8); limit 20;",
+    },
+    Puzzle: {
+      id: 9,
+      title: "Puzzle",
+      query:
+        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (9); limit 20;",
+    },
+    Racing: {
+      id: 10,
+      title: "Racing",
+      query:
+        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (10); limit 20;",
+    },
+    RTS: {
+      id: 11,
+      title: "Real Time Strategy",
+      query:
+        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (11); limit 20;",
+    },
+    RPG: {
+      id: 12,
+      title: "Role Playing Game",
+      query:
+        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (12); limit 20;",
+    },
+    Simulator: {
+      id: 13,
+      title: "Simulator",
+      query:
+        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (13); limit 20;",
+    },
+    Sport: {
+      id: 14,
+      title: "Sport",
+      query:
+        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (14); limit 20;",
+    },
+    Strategy: {
+      id: 15,
+      title: "Strategy",
+      query:
+        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (15); limit 20;",
+    },
+    TurnBased: {
+      id: 16,
+      title: "Turn-Based Strategy",
+      query:
+        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (16); limit 20;",
+    },
+    Tactical: {
+      id: 24,
+      title: "Tactical",
+      query:
+        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (24); limit 20;",
+    },
+    // QuizTrivia: {
+    //   id: 26,
+    //   title: "Quiz/Trivia",
+    //   query: buildRequest(
+    //     "igdb",
+    //     "games",
+    //     "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (26); limit 20;"
+    //   ),
+    // },
+    HackandSlash: {
+      id: 25,
+      title: "Hack and Slash",
+      query:
+        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (25); limit 20;",
+    },
+    // Pinball: {
+    //   id: 30,
+    //   title: "Pinball",
+    //   query: buildRequest(
+    //     "igdb",
+    //     "games",
+    //     "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (30); limit 20;"
+    //   ),
+    // },
+    Adventure: {
+      id: 31,
+      title: "Adventure",
+      query:
+        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (31); limit 20;",
+    },
+    Arcade: {
+      id: 33,
+      title: "Arcade",
+      query:
+        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (33); limit 20;",
+    },
+    VisualNovel: {
+      id: 34,
+      title: "Visual Novel",
+      query:
+        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (34); limit 20;",
+    },
+    Indie: {
+      id: 32,
+      title: "Indie",
+      query:
+        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (32); limit 20;",
+    },
+    CardBoard: {
+      id: 35,
+      title: "Card and Board Games",
+      query:
+        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (35); limit 20;",
+    },
+    // MOBA: {
+    //   id: 36,
+    //   title: "MOBA",
+    //   query: buildRequest(
+    //     "igdb",
+    //     "games",
+    //     "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (36); limit 20;"
+    //   ),
+    // },
+  },
 };

--- a/utils/requests.js
+++ b/utils/requests.js
@@ -1,226 +1,5 @@
-import buildRequest from "./buildRequest";
-// TODO: define each type of requests
 export default {
   home: {
-    TopGames: {
-      id: 0,
-      title: "Top Games",
-      promise: buildRequest(
-        "igdb",
-        "games",
-        "fields name, slug, cover.url, screenshots.url, rating, summary; sort aggregated_rating_count desc; where aggregated_rating >= 90; limit 20;"
-      ),
-    },
-    PointandClick: {
-      id: 2,
-      title: "Point-and-Click",
-      promise: buildRequest(
-        "igdb",
-        "games",
-        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (2); limit 20;"
-      ),
-    },
-    Fighting: {
-      id: 4,
-      title: "Fighting",
-      promise: buildRequest(
-        "igdb",
-        "games",
-        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (4); limit 20;"
-      ),
-    },
-    Shooter: {
-      id: 5,
-      title: "Shooter",
-      promise: buildRequest(
-        "igdb",
-        "games",
-        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (5); limit 20;"
-      ),
-    },
-    Music: {
-      id: 7,
-      title: "Music",
-      promise: buildRequest(
-        "igdb",
-        "games",
-        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (7); limit 20;"
-      ),
-    },
-    Platform: {
-      id: 8,
-      title: "Platform",
-      promise: buildRequest(
-        "igdb",
-        "games",
-        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (8); limit 20;"
-      ),
-    },
-    Puzzle: {
-      id: 9,
-      title: "Puzzle",
-      promise: buildRequest(
-        "igdb",
-        "games",
-        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (9); limit 20;"
-      ),
-    },
-    Racing: {
-      id: 10,
-      title: "Racing",
-      promise: buildRequest(
-        "igdb",
-        "games",
-        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (10); limit 20;"
-      ),
-    },
-    RTS: {
-      id: 11,
-      title: "Real Time Strategy",
-      promise: buildRequest(
-        "igdb",
-        "games",
-        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (11); limit 20;"
-      ),
-    },
-    RPG: {
-      id: 12,
-      title: "Role Playing Game",
-      promise: buildRequest(
-        "igdb",
-        "games",
-        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (12); limit 20;"
-      ),
-    },
-    Simulator: {
-      id: 13,
-      title: "Simulator",
-      promise: buildRequest(
-        "igdb",
-        "games",
-        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (13); limit 20;"
-      ),
-    },
-    Sport: {
-      id: 14,
-      title: "Sport",
-      promise: buildRequest(
-        "igdb",
-        "games",
-        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (14); limit 20;"
-      ),
-    },
-    Strategy: {
-      id: 15,
-      title: "Strategy",
-      promise: buildRequest(
-        "igdb",
-        "games",
-        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (15); limit 20;"
-      ),
-    },
-    TurnBased: {
-      id: 16,
-      title: "Turn-Based Strategy",
-      promise: buildRequest(
-        "igdb",
-        "games",
-        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (16); limit 20;"
-      ),
-    },
-    Tactical: {
-      id: 24,
-      title: "Tactical",
-      promise: buildRequest(
-        "igdb",
-        "games",
-        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (24); limit 20;"
-      ),
-    },
-    // QuizTrivia: {
-    //   id: 26,
-    //   title: "Quiz/Trivia",
-    //   promise: buildRequest(
-    //     "igdb",
-    //     "games",
-    //     "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (26); limit 20;"
-    //   ),
-    // },
-    HackandSlash: {
-      id: 25,
-      title: "Hack and Slash",
-      promise: buildRequest(
-        "igdb",
-        "games",
-        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (25); limit 20;"
-      ),
-    },
-    // Pinball: {
-    //   id: 30,
-    //   title: "Pinball",
-    //   promise: buildRequest(
-    //     "igdb",
-    //     "games",
-    //     "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (30); limit 20;"
-    //   ),
-    // },
-    Adventure: {
-      id: 31,
-      title: "Adventure",
-      promise: buildRequest(
-        "igdb",
-        "games",
-        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (31); limit 20;"
-      ),
-    },
-    Arcade: {
-      id: 33,
-      title: "Arcade",
-      promise: buildRequest(
-        "igdb",
-        "games",
-        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (33); limit 20;"
-      ),
-    },
-    VisualNovel: {
-      id: 34,
-      title: "Visual Novel",
-      promise: buildRequest(
-        "igdb",
-        "games",
-        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (34); limit 20;"
-      ),
-    },
-    Indie: {
-      id: 32,
-      title: "Indie",
-      promise: buildRequest(
-        "igdb",
-        "games",
-        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (32); limit 20;"
-      ),
-    },
-    CardBoard: {
-      id: 35,
-      title: "Card and Board Games",
-      promise: buildRequest(
-        "igdb",
-        "games",
-        "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (35); limit 20;"
-      ),
-    },
-    // MOBA: {
-    //   id: 36,
-    //   title: "MOBA",
-    //   promise: buildRequest(
-    //     "igdb",
-    //     "games",
-    //     "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (36); limit 20;"
-    //   ),
-    // },
-  },
-
-  home2: {
     TopGames: {
       id: 0,
       title: "Top Games",
@@ -314,11 +93,9 @@ export default {
     // QuizTrivia: {
     //   id: 26,
     //   title: "Quiz/Trivia",
-    //   query: buildRequest(
-    //     "igdb",
-    //     "games",
+    //   query:
     //     "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (26); limit 20;"
-    //   ),
+    //   ,
     // },
     HackandSlash: {
       id: 25,
@@ -329,11 +106,9 @@ export default {
     // Pinball: {
     //   id: 30,
     //   title: "Pinball",
-    //   query: buildRequest(
-    //     "igdb",
-    //     "games",
+    //   query:
     //     "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (30); limit 20;"
-    //   ),
+    //   ,
     // },
     Adventure: {
       id: 31,
@@ -368,11 +143,9 @@ export default {
     // MOBA: {
     //   id: 36,
     //   title: "MOBA",
-    //   query: buildRequest(
-    //     "igdb",
-    //     "games",
+    //   query:
     //     "fields name, slug, cover.url; sort aggregated_rating_count desc; where aggregated_rating >= 90 & genres = (36); limit 20;"
-    //   ),
+    //   ,
     // },
   },
 };


### PR DESCRIPTION
Fixed error by hitting the '[multiquery](https://api-docs.igdb.com/#multi-query)' endpoint. This endpoint allows us to perform up to 10 queries in one request and helps us avoid hitting the rate limit.

** NOTE: Rate limit is 4 requests per second! It won't immediately stop you, but it will throw an error on subsequent calls. Read up on IGDB's [Rate Limit](https://api-docs.igdb.com/#rate-limits)